### PR TITLE
Disable axe color contrast checks

### DIFF
--- a/src/axe.ts
+++ b/src/axe.ts
@@ -57,10 +57,20 @@ function configureAxe(
 ) => Promise<AxeCore.AxeResults> {
   let { globalOptions = {}, ...runnerOptions } = options;
 
-  // Set the global configuration for
-  // axe-core
+  // Set the global configuration for axe-core
   // https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#api-name-axeconfigure
-  configure(globalOptions);
+  const { checks = [], ...otherGlobalOptions } = globalOptions
+  configure({
+    checks: [
+      {
+        // color contrast checking doesnt work in a jsdom environment.
+        id: 'color-contrast',
+        enabled: false
+      },
+      ...checks
+    ],
+    ...otherGlobalOptions
+  })
 
   /**
    * Small wrapper for axe-core#run that enables promises, default options and


### PR DESCRIPTION
This applies the same patch that was added to jest-axe last year (https://github.com/NickColley/jest-axe/commit/48824b2400b23bf2ff11bcccd090cf868b4fd8ec). Without this, you'll see errors like:

```output
Error: Not implemented: window.computedStyle(elt, pseudoElt)
```