### PR TITLE
Revert "Remove github workflows"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,8 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 8
-          run_install: true
+          run_install: |
+            - args: [--frozen-lockfile]
 
       - name: Lint
         run: pnpm lint
@@ -53,7 +54,8 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 8
-          run_install: true
+          run_install: |
+            - args: [--frozen-lockfile]
 
       - name: Test
         run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - ci
   pull_request:
 
 concurrency:
@@ -11,25 +12,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
-          run_install: true
-
-      - name: Build
-        run: pnpm build
 
   lint:
     runs-on: ubuntu-latest
@@ -53,8 +35,9 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [16.x, 18.x, 20.x]
+        # os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
+        # node-version: [16.x, 18.x, 20.x]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -63,7 +46,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          # node-version: ${{ matrix.node-version }}
+          node-version-file: '.nvmrc'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,8 @@ jobs:
     name: Test 🧪
     strategy:
       matrix:
-        # os: [ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-latest]
-        # node-version: [16.x, 18.x, 20.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: [16.x, 18.x, 20.x]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -72,8 +71,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          # node-version: ${{ matrix.node-version }}
-          node-version-file: '.nvmrc'
+          node-version: ${{ matrix.node-version }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: true
+
+      - name: Build
+        run: pnpm build
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: true
+
+      - name: Lint
+        run: pnpm lint
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: [16.x, 18.x, 20.x]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: true
+
+      - name: Test
+        run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - ci
+      - dev
   pull_request:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,5 @@ jobs:
 
       - name: Test
         run: pnpm test
+        env:
+          FORCE_COLOR: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: ci
+name: CI
 
 on:
   push:
@@ -13,7 +13,30 @@ concurrency:
 
 jobs:
 
+  build:
+    name: Build 🛠️
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: |
+            - args: [--frozen-lockfile]
+
+      - name: Build
+        run: pnpm build
+
   lint:
+    name: Lint 🔎
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,7 +56,9 @@ jobs:
 
       - name: Lint
         run: pnpm lint
+
   test:
+    name: Test 🧪
     strategy:
       matrix:
         # os: [ubuntu-latest, macos-latest, windows-latest]


### PR DESCRIPTION
This reverts commit db7b4c0.

@drwpow These were failing because Chalk disables color when the CI environment variable is set to true, and our snapshots included its color tags. Setting `FORCE_COLOR=2` fixes this.

Thanks again for the push here!